### PR TITLE
Bump version to 1.2 to fix App Store submission

### DIFF
--- a/HowHigh/HowHigh.xcodeproj/project.pbxproj
+++ b/HowHigh/HowHigh.xcodeproj/project.pbxproj
@@ -414,7 +414,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1;
+				MARKETING_VERSION = 1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.LuckyBunny.HowHigh;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -445,7 +445,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1;
+				MARKETING_VERSION = 1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.LuckyBunny.HowHigh;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;


### PR DESCRIPTION
Fixes ITMS-90186 and ITMS-90062 errors from App Store Connect. Version 1.1 was previously approved, so bumping to 1.2 for new submission.

Updates MARKETING_VERSION in the SwiftUI project (HowHigh/HowHigh.xcodeproj). Build number remains at 1 as Xcode Cloud will auto-increment it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)